### PR TITLE
Update evaluate_multianimal.py

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -343,9 +343,8 @@ def evaluate_multianimal_full(
                         # Form 2D array of shape (n_rows, 4) where the last dim is
                         # (sample_index, peak_y, peak_x, bpt_index) to slice the PAFs.
                         temp = df.reset_index(level="bodyparts").dropna()
-                        temp["bodyparts"].replace(
+                        temp["bodyparts"] = temp["bodyparts"].replace(
                             dict(zip(joints, range(len(joints)))),
-                            inplace=True,
                         )
                         temp["sample"] = 0
                         peaks_gt = temp.loc[


### PR DESCRIPTION
Fix pandas FutureWarning in `evaluate_multianimal.py` related to `inplace=True` in `.replace()`

This Pull Request addresses a `FutureWarning` originating from the pandas library that appears during the evaluation of multi-animal pose estimation models in DeepLabCut.

**Problem:**

The warning is triggered by the use of the `.replace()` method with the `inplace=True` argument in the `evaluate_multianimal.py` file (likely around line [**Insert the line number you found, e.g., 346**]). Pandas is discouraging the use of `inplace=True` in combination with chained assignment, as it can lead to unexpected behavior and will be removed in a future version.

**Solution:**

This PR modifies the line to remove the `inplace=True` argument and instead assigns the result of the `.replace()` operation back to the DataFrame column. For example, the line was changed from:

```python
temp["bodyparts"].replace(..., inplace=True)