### PR TITLE
Fix bone likelihood in analyzebone to use both bodyparts

### DIFF
--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -156,7 +156,7 @@ def analyzebone(bp1, bp2):
     bone_orientation = calc_angle_between_vectors_of_points_2d(bp1_pos.T, bp2_pos.T)
 
     # keep the smallest of the two likelihoods
-    likelihoods = np.vstack([bp2.likelihood.values, bp2.likelihood.values]).T
+    likelihoods = np.vstack([bp1.likelihood.values, bp2.likelihood.values]).T
     likelihood = np.min(likelihoods, 1)
 
     # Create dataframe and return


### PR DESCRIPTION
## Bug

`analyzebone()` in `deeplabcut/post_processing/analyze_skeleton.py` computed each skeleton bone's likelihood as `min(bp2.likelihood, bp2.likelihood)` — the second bodypart was stacked twice and `bp1` was discarded:

```python
# keep the smallest of the two likelihoods
likelihoods = np.vstack([bp2.likelihood.values, bp2.likelihood.values]).T
likelihood = np.min(likelihoods, 1)
```

The adjacent comment states the intent ("keep the smallest of the two likelihoods"), so the result should be `min(bp1.likelihood, bp2.likelihood)`.

## Impact

A bone whose first bodypart is occluded (low confidence) but whose second bodypart is confident was reported as fully confident, silently corrupting the `likelihood` column of every skeleton analysis output and any downstream confidence thresholding.

## Fix

One line — use `bp1` for the first stacked row:

```python
likelihoods = np.vstack([bp1.likelihood.values, bp2.likelihood.values]).T
```

Verified: with `bp1=[0.05, 0.90]`, `bp2=[0.99, 0.20]`, the bone likelihood is now `[0.05, 0.20]` (elementwise min) instead of the previous `[0.99, 0.20]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ErxFDuCkdxHvigvusf4NB)_