### PR TITLE
Fix CondFromModel loading the config path as its snapshot

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/data/ctd.py
+++ b/deeplabcut/pose_estimation_pytorch/data/ctd.py
@@ -477,7 +477,7 @@ class CondFromModel(CondProvider):
     ) -> None:
         if config_path is not None and snapshot_path is not None:
             config_path = Path(config_path)
-            snapshot_path = Path(config_path)
+            snapshot_path = Path(snapshot_path)
         elif "config" in kwargs and "shuffle" in kwargs:
             bu_loader, snapshot = self.get_loader_and_snapshot(**kwargs)
             config_path = bu_loader.model_config_path


### PR DESCRIPTION
## Bug

`CondFromModel.__init__` in `deeplabcut/pose_estimation_pytorch/data/ctd.py` overwrote the snapshot path with the config path (copy-paste error):

```python
if config_path is not None and snapshot_path is not None:
    config_path = Path(config_path)
    snapshot_path = Path(config_path)   # <- should be Path(snapshot_path)
```

## Impact

This is the documented way to configure bottom-up conditions for CTD:

```yaml
inference:
  conditions:
    config_path: /path/model-dir/pytorch_config.yaml
    snapshot_path: /path/model-dir/snapshot-best-150.pth
```

Both are non-None, so this branch runs and `self.snapshot_path` ends up pointing at the `pytorch_config.yaml`. Downstream, `torch.load()` is called on the YAML → the conditioning model can never load via this path.

## Fix

```python
snapshot_path = Path(snapshot_path)
```


---
_Generated by [Claude Code](https://claude.ai/code/session_013ErxFDuCkdxHvigvusf4NB)_