### PR TITLE
Fix SORTSkeleton removing the wrong tracker on cleanup

### DIFF
--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -601,7 +601,7 @@ class SORTSkeleton(SORTBase):
         for tracker in reversed(self.trackers):
             i -= 1
             if tracker.time_since_update > self.max_age:
-                self.trackers.pop()
+                self.trackers.pop(i)
                 continue
             state = tracker.predict()
             states.append(np.r_[state, [tracker.id, int(animalindex[i])]])


### PR DESCRIPTION
## Bug

In `SORTSkeleton.track` (`deeplabcut/core/trackingutils.py`), the reverse-iteration cleanup loop maintains `i` as the current tracker's index but removed dead trackers with `self.trackers.pop()` (removes the **last** element) instead of `self.trackers.pop(i)`:

```python
i = len(self.trackers)
for tracker in reversed(self.trackers):
    i -= 1
    if tracker.time_since_update > self.max_age:
        self.trackers.pop()      # should be pop(i)
        continue
    state = tracker.predict()
    states.append(np.r_[state, [tracker.id, int(animalindex[i])]])
```

The sibling classes `SORTBox` and `SORTEllipse` (same file) correctly use `self.trackers.pop(i)`, confirming the intent.

## Impact

With `self.trackers = [A, B, C]` where only the middle tracker `B` is stale: when the loop reaches `B`, `pop()` deletes `C` (the last element) instead of `B`. The dead tracker persists, a live tracker is dropped, and `animalindex[i]` alignment breaks — corrupting identity/tracklet assignment in subsequent frames for the `skeleton` track method.

## Fix

```python
self.trackers.pop(i)
```


---
_Generated by [Claude Code](https://claude.ai/code/session_013ErxFDuCkdxHvigvusf4NB)_