### PR TITLE
Fix CTD tracklet-age reset writing to a non-existent attribute

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -801,7 +801,7 @@ class CTDInferenceRunner(PoseInferenceRunner):
         else:
             self._prev_pose = None
             self._idx_to_id = None
-            self._idx_ages = None
+            self._ctd_track_ages = None
 
     def _merge_conditions(self, bu_cond: np.ndarray) -> np.ndarray:
         """Merges conditions made by a BU model with existing conditions from CTD


### PR DESCRIPTION
## Bug

In `deeplabcut/pose_estimation_pytorch/runners/inference.py`, when a frame loses all individuals (NMS mask all-False), the reset branch assigns:

```python
else:
    self._prev_pose = None
    self._idx_to_id = None
    self._idx_ages = None        # wrong attribute
```

The tracking-age attribute is `_ctd_track_ages` (initialised in `__init__`, used by `_ctd_tracking_postprocess`). `_idx_ages` is never read anywhere in the class, so this reset silently did nothing — it just created a new dead attribute while leaving `_ctd_track_ages` stale.

## Impact

`_ctd_track_ages` keeps its stale values across the all-empty frame. On the next BU-seeded frame, `_ctd_tracking_postprocess` sees `_ctd_track_ages is not None` and uses it as the OKS-NMS ordering, biasing suppression toward stale-old indices → the wrong pose/identity is retained, and because ages keep accumulating on the stale base the bias compounds over subsequent frames. The intended behaviour (reset to `None` → fall back to score ordering) never happened.

## Fix

```python
self._ctd_track_ages = None
```


---
_Generated by [Claude Code](https://claude.ai/code/session_013ErxFDuCkdxHvigvusf4NB)_