### PR TITLE
Fix destfolder leaking across videos in filter/skeleton loops

### DIFF
--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -271,13 +271,14 @@ def analyzeskeleton(
     Videos = collect_video_paths(videos, extensions=video_extensions)
     for video in Videos:
         print(f"Processing {video}")
-        if destfolder is None:
-            destfolder = str(Path(video).parents[0])
+        videofolder = destfolder
+        if videofolder is None:
+            videofolder = str(Path(video).parents[0])
 
         vname = Path(video).stem
         try:
             df, filepath, scorer, _ = auxiliaryfunctions.load_analyzed_data(
-                destfolder, vname, DLCscorer, filtered, track_method
+                videofolder, vname, DLCscorer, filtered, track_method
             )
         except FileNotFoundError as e:
             print(e)

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -235,14 +235,17 @@ def filterpredictions(
             return video_to_filtered_df
 
     for video in Videos:
-        if destfolder is None:
-            destfolder = str(Path(video).parents[0])
+        videofolder = destfolder
+        if videofolder is None:
+            videofolder = str(Path(video).parents[0])
 
         print(f"Filtering with {filtertype} model {video}")
         vname = Path(video).stem
 
         try:
-            df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(destfolder, vname, DLCscorer, True, track_method)
+            df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
+                videofolder, vname, DLCscorer, True, track_method
+            )
             print(f"Data from {vname} were already filtered. Skipping...")
             video_to_filtered_df[video] = df
             # Data has been filtered so continue to the next video
@@ -253,7 +256,7 @@ def filterpredictions(
         # Data haven't been filtered yet
         try:
             df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
-                destfolder, vname, DLCscorer, track_method=track_method
+                videofolder, vname, DLCscorer, track_method=track_method
             )
         except FileNotFoundError as e:
             video_to_filtered_df[video] = None


### PR DESCRIPTION
## Bug

`filterpredictions()` (`post_processing/filtering.py`) and `analyzeskeleton()` (`post_processing/analyze_skeleton.py`) reassign the `destfolder` **parameter** inside their `for video in Videos:` loop when it is `None`:

```python
for video in Videos:
    if destfolder is None:
        destfolder = str(Path(video).parents[0])
```

After the first iteration `destfolder` is pinned to the first video's folder for the rest of the loop.

## Impact

With `destfolder=None` (the default) and videos in different folders, e.g. `["/data/expA/vid1.mp4", "/data/expB/vid2.mp4"]`: iteration 1 sets `destfolder="/data/expA"`, then iteration 2 looks up `vid2` in `/data/expA`, so `load_analyzed_data` raises `FileNotFoundError` and `vid2` is silently recorded as "not analyzed" even though its results exist in `/data/expB`. This contradicts the documented behaviour ("If None, the path of the video is used").

The correctly-written `plot_trajectories` and `extract_outlier_frames` compute a fresh per-iteration folder instead.

## Fix

Use a per-iteration local `videofolder` and stop mutating the `destfolder` parameter.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ErxFDuCkdxHvigvusf4NB)_