### PR TITLE
Fix except clause catching a ValueError instance instead of the type

### DIFF
--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -480,7 +480,7 @@ def extract_outlier_frames(
                 if frames2use is not None:
                     try:
                         frames2use = np.array(frames2use).astype("int")
-                    except ValueError():
+                    except ValueError:
                         print(
                             "Could not cast frames2use into np array, "
                             "please check that frames2use is a simply a list of integers!"


### PR DESCRIPTION
## Bug

In `extract_outlier_frames` (`deeplabcut/refine_training_dataset/outlier_frames.py`), the `outlieralgorithm="list"` branch has:

```python
try:
    frames2use = np.array(frames2use).astype("int")
except ValueError():   # note the parentheses
    print("Could not cast frames2use ...")
    raise
```

`except ValueError()` evaluates `ValueError()` to an **instance**. When the `try` body raises a `ValueError`, Python's exception matching finds a non-class handler and raises `TypeError: catching classes that do not inherit from BaseException is not allowed`, masking the real error and the intended message.

## Impact

`extract_outlier_frames(..., outlieralgorithm="list", frames2use=["a", "b"])` → `np.array(["a","b"]).astype("int")` raises `ValueError`, but instead of printing the helpful message and re-raising the `ValueError`, the handler raises a confusing `TypeError`.

## Fix

```python
except ValueError:
```

Verified: `except ValueError()` raises `TypeError: catching classes that do not inherit from BaseException is not allowed`; `except ValueError` catches correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ErxFDuCkdxHvigvusf4NB)_