### PR TITLE
Import scipy.ndimage functions directly (drop removed measurements namespace)

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/predict_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/predict_multianimal.py
@@ -12,7 +12,7 @@
 
 import numpy as np
 import tensorflow as tf
-from scipy.ndimage import measurements
+from scipy.ndimage import center_of_mass, label
 from skimage.feature import peak_local_max
 
 
@@ -262,8 +262,8 @@ def find_local_maxima(scmap, radius, threshold):
     peak_idx = peak_local_max(scmap, min_distance=radius, threshold_abs=threshold, exclude_border=False)
     grid = np.zeros_like(scmap, dtype=bool)
     grid[tuple(peak_idx.T)] = True
-    labels = measurements.label(grid)[0]
-    xy = measurements.center_of_mass(grid, labels, range(1, np.max(labels) + 1))
+    labels = label(grid)[0]
+    xy = center_of_mass(grid, labels, range(1, np.max(labels) + 1))
     return np.asarray(xy, dtype=int).reshape((-1, 2))
 
 


### PR DESCRIPTION
## Bug

`deeplabcut/pose_estimation_tensorflow/core/predict_multianimal.py` imports:

```python
from scipy.ndimage import measurements
```

The `scipy.ndimage.measurements` submodule was deprecated in scipy 1.8 and **removed in scipy 1.14**. The project pins `scipy>=1.9` with **no upper bound**, so a fresh install resolves a scipy where this import raises `ImportError: cannot import name 'measurements'` at module load.

## Impact

This module is imported at the top of the TensorFlow multi-animal inference path, so `analyze_videos` on a TF maDLC project fails **immediately on import**, before any function runs.

## Fix

Import `label` and `center_of_mass` directly from `scipy.ndimage` (their canonical public location) and drop the `measurements.` prefix:

```python
from scipy.ndimage import center_of_mass, label
...
labels = label(grid)[0]
xy = center_of_mass(grid, labels, range(1, np.max(labels) + 1))
```

These functions have been importable directly from `scipy.ndimage` for many years, so this is compatible with both old and new scipy.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ErxFDuCkdxHvigvusf4NB)_