### PR TITLE
Replace removed np.object alias with builtin object

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/test.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/test.py
@@ -48,7 +48,7 @@ def test_net(visualise, cache_scoremaps):
             os.makedirs(out_dir)
 
     num_images = dataset.num_images
-    predictions = np.zeros((num_images,), dtype=np.object)
+    predictions = np.zeros((num_images,), dtype=object)
 
     for k in range(num_images):
         print(f"processing image {k}/{num_images - 1}")


### PR DESCRIPTION
## Bug

`deeplabcut/pose_estimation_tensorflow/core/test.py` uses:

```python
predictions = np.zeros((num_images,), dtype=np.object)
```

`np.object` was a deprecated alias for the builtin `object` and was **removed in numpy 1.24**, so it raises `AttributeError: module 'numpy' has no attribute 'object'` under the pinned numpy (`>=1.18.5,<2` resolves to 1.26).

## Impact

Reached when running the TensorFlow `test_net` diagnostic (`core/test.py`). A rarely-used debug entry point, but the line is genuinely broken on any supported numpy.

## Fix

```python
dtype=object
```


---
_Generated by [Claude Code](https://claude.ai/code/session_013ErxFDuCkdxHvigvusf4NB)_