### PR TITLE
Fix operator precedence in condition NaN/non-positive mask

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -664,7 +664,7 @@ class CTDInferenceRunner(PoseInferenceRunner):
 
         # Extract the conditions
         conds = predictions["bodyparts"][..., :3]
-        pred_mask = ~np.all(np.any(conds <= 0 | np.isnan(conds), axis=2), axis=1)
+        pred_mask = ~np.all(np.any((conds <= 0) | np.isnan(conds), axis=2), axis=1)
         if np.sum(pred_mask) > 0:
             conds = conds[pred_mask]
         else:


### PR DESCRIPTION
## Bug

In `deeplabcut/pose_estimation_pytorch/runners/inference.py`:

```python
pred_mask = ~np.all(np.any(conds <= 0 | np.isnan(conds), axis=2), axis=1)
```

Bitwise `|` binds tighter than the `<=` comparison, so `conds <= 0 | np.isnan(conds)` parses as `conds <= (0 | np.isnan(conds))` — the NaN check is not OR-ed with the non-positive check as intended.

## Impact

The intent is to flag condition entries that are non-positive **or** NaN. As written, NaN entries are not correctly flagged. Verified:

```
conds = [0.5, -0.1, nan]
buggy: [False, True, False]   # misses the NaN
fixed: [False, True, True]
```

(In the current pipeline the effect is usually masked because all-NaN rows are padded with `-1` upstream, but the expression is still incorrect.)

## Fix

```python
pred_mask = ~np.all(np.any((conds <= 0) | np.isnan(conds), axis=2), axis=1)
```


---
_Generated by [Claude Code](https://claude.ai/code/session_013ErxFDuCkdxHvigvusf4NB)_