### PR TITLE
Fix scipy.stats.mode usage for keepdims=False default (scipy>=1.11)

### DIFF
--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -418,7 +418,7 @@ class SORTEllipse(SORTBase):
             if el is not None:
                 ellipses.append(el)
                 if identities is not None:
-                    pred_ids.append(mode(identities[i])[0][0])
+                    pred_ids.append(mode(identities[i], keepdims=False)[0])
         if not len(trackers):
             matches = np.empty((0, 2), dtype=int)
             unmatched_detections = np.arange(len(ellipses))
@@ -470,7 +470,7 @@ class SORTEllipse(SORTBase):
         for i in unmatched_detections:
             trk = EllipseTracker(ellipses[i].parameters)
             if identities is not None:
-                trk.id_ = mode(identities[i])[0][0]
+                trk.id_ = mode(identities[i], keepdims=False)[0]
             self.trackers.append(trk)
             animalindex.append(i)
 


### PR DESCRIPTION
## Bug

`SORTEllipse.track` in `deeplabcut/core/trackingutils.py` indexes `mode(identities[i])[0][0]` at two sites. Since scipy 1.11, `scipy.stats.mode` defaults to `keepdims=False`, so `mode(1d)[0]` is already a scalar and the trailing `[0]` raises `IndexError: invalid index to scalar variable`.

## Fix

Pass `keepdims=False` explicitly and take a single `[0]`, matching the pattern already used in `refine_training_dataset/stitch.py`:

```python
mode(identities[i], keepdims=False)[0]
```

## Note

These two sites are inside the identity-aware branch of `SORTEllipse.track`, which is only reached when `identities` is passed to `track()`. No in-tree caller currently does this (callers use the separate `linear_sum_assignment` path), so this is a **latent** fix rather than a live regression — but it removes a real breakage should that branch be exercised, and aligns with the already-fixed `stitch.py` call.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ErxFDuCkdxHvigvusf4NB)_